### PR TITLE
Update Byte Buddy to 1.12.6 (fixes #3)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -29,7 +29,7 @@ configurations {
 }
 
 dependencies {
-    implementation group: 'net.bytebuddy', name: 'byte-buddy-dep', version: '1.10.20'
+    implementation group: 'net.bytebuddy', name: 'byte-buddy-dep', version: '1.12.6'
 
     // Dependencies we load only as part of rewriting them, iff the target app includes them:
     compileOnly group: 'commons-httpclient', name: 'commons-httpclient', version: '3.1'


### PR DESCRIPTION
Increases byte buddy version so Java 17 (and newer) ASM is supported.

Tested locally by replacing installed agent with this build - all looks fine.

![image](https://user-images.githubusercontent.com/17074375/146911008-18dec538-c45d-47c6-8513-3bbe6b8f064d.png)
