### PR TITLE
Fix corner case with Apache HTTP client v4 + RestEasy.

### DIFF
--- a/src/main/java/tech/httptoolkit/javaagent/advice/apacheclient/ApacheSetSslSocketFactoryAdvice.java
+++ b/src/main/java/tech/httptoolkit/javaagent/advice/apacheclient/ApacheSetSslSocketFactoryAdvice.java
@@ -4,7 +4,6 @@ import net.bytebuddy.asm.Advice;
 
 import javax.net.ssl.SSLContext;
 import java.lang.reflect.Field;
-import java.security.NoSuchAlgorithmException;
 import java.util.Arrays;
 
 public class ApacheSetSslSocketFactoryAdvice {
@@ -17,7 +16,7 @@ public class ApacheSetSslSocketFactoryAdvice {
         for (String factoryFieldName : Arrays.asList("socketfactory", "socketFactory")) {
             try {
                 // Detect which field(s) are present on this class
-                Field field = thisFactory.getClass().getDeclaredField(factoryFieldName);
+                Field field = getDeclaredFieldInClassTree(thisFactory.getClass(), factoryFieldName);
 
                 // Allow ourselves to change the socket factory value
                 field.setAccessible(true);
@@ -32,4 +31,14 @@ public class ApacheSetSslSocketFactoryAdvice {
             throw new IllegalStateException("Apache HttpClient interception setup failed");
         }
     }
+
+    public static Field getDeclaredFieldInClassTree(Class<?> type, String fieldName) throws NoSuchFieldException {
+        for (Class<?> clazz = type; clazz != null; clazz = clazz.getSuperclass()) {
+            try {
+                return clazz.getDeclaredField(fieldName);
+            } catch (NoSuchFieldException ignored) { }
+        }
+        throw new NoSuchFieldException();
+    }
+    
 }

--- a/test-app/build.gradle
+++ b/test-app/build.gradle
@@ -35,6 +35,8 @@ dependencies {
 
     implementation group: 'io.vertx', name: 'vertx-core', version: '4.2.2'
     implementation group: 'io.vertx', name: 'vertx-web-client', version: '4.2.2'
+
+    implementation group: 'org.jboss.resteasy', name: 'resteasy-client', version: '4.7.4.Final'
 }
 
 test {

--- a/test-app/src/main/java/tech/httptoolkit/testapp/Main.java
+++ b/test-app/src/main/java/tech/httptoolkit/testapp/Main.java
@@ -17,6 +17,7 @@ public class Main {
     private static final Map<String, ClientCase<?>> cases = Map.ofEntries(
         entry("apache-v3", new ApacheHttpClientV3Case()),
         entry("apache-v4", new ApacheHttpClientV4Case()),
+        entry("rest-easy-with-apache-v4", new RestEasyWithApacheHttpClientV4Case()),
         entry("apache-v5", new ApacheHttpClientV5Case()),
         entry("apache-async-v4", new ApacheHttpAsyncClientV4Case()),
         entry("apache-async-v5", new ApacheHttpAsyncClientV5Case()),

--- a/test-app/src/main/java/tech/httptoolkit/testapp/cases/RestEasyWithApacheHttpClientV4Case.java
+++ b/test-app/src/main/java/tech/httptoolkit/testapp/cases/RestEasyWithApacheHttpClientV4Case.java
@@ -1,0 +1,36 @@
+package tech.httptoolkit.testapp.cases;
+
+import org.jboss.resteasy.client.jaxrs.ResteasyClient;
+import org.jboss.resteasy.client.jaxrs.engines.ClientHttpEngineBuilder43;
+import org.jboss.resteasy.client.jaxrs.internal.ResteasyClientBuilderImpl;
+
+import javax.net.ssl.SSLContext;
+import java.io.IOException;
+import java.net.MalformedURLException;
+import java.net.URI;
+import java.security.NoSuchAlgorithmException;
+
+public class RestEasyWithApacheHttpClientV4Case extends ClientCase<ResteasyClient> {
+
+    @Override
+    public ResteasyClient newClient(String url) throws MalformedURLException {
+        ResteasyClientBuilderImpl resteasyClientBuilder = new ResteasyClientBuilderImpl();
+        resteasyClientBuilder.sslContext(getSslContext());
+        resteasyClientBuilder.httpEngine(new ClientHttpEngineBuilder43()
+                .resteasyClientBuilder(resteasyClientBuilder).build());
+        return resteasyClientBuilder.build();
+    }
+
+    @Override
+    public int test(String url, ResteasyClient resteasyClient) throws IOException {
+        return resteasyClient.target(URI.create(url)).request().get().getStatus();
+    }
+
+    private SSLContext getSslContext() {
+        try {
+            return SSLContext.getDefault();
+        } catch (NoSuchAlgorithmException e) {
+            throw new IllegalStateException(e);
+        }
+    }
+}


### PR DESCRIPTION
Fix Apache Http Client interception bug when creating an anonymous class of SSLConnectionSocketFactory. When creating an anonymous class getDeclaredField will not return the needed socketFactory attribute. This is the behavior of RestEasy for some cases, see https://github.com/resteasy/Resteasy/blob/main/resteasy-client/src/main/java/org/jboss/resteasy/client/jaxrs/engines/ClientHttpEngineBuilder43.java#L128

Fix https://github.com/httptoolkit/jvm-http-proxy-agent/issues/2