### PR TITLE
Don't pollute std out

### DIFF
--- a/src/main/kotlin/tech/httptoolkit/javaagent/AgentMain.kt
+++ b/src/main/kotlin/tech/httptoolkit/javaagent/AgentMain.kt
@@ -127,7 +127,7 @@ fun interceptAllHttps(config: Config, instrumentation: Instrumentation) {
 
     agentBuilder.installOn(instrumentation)
 
-    println("HTTP Toolkit interception active")
+    System.err.println("HTTP Toolkit interception active")
 }
 
 abstract class MatchingAgentTransformer(private val logger: TransformationLogger) : AgentBuilder.Transformer {


### PR DESCRIPTION
minimal fixes for #18 

this makes http toolkit not interfere with clis and other apps that send content on standard out.